### PR TITLE
Promote Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
-----
+The Teradata JDBC Driver enables Java applications to connect to the Teradata Database. The driver is available in [Maven Central](https://search.maven.org/search?q=a:terajdbc). 
 
-### [Download Teradata JDBC Driver](https://downloads.teradata.com/download/connectivity/jdbc-driver)
-
-----
-
-The Teradata JDBC Driver enables Java applications to connect to the Teradata Database.
-
-See the readme file in each download package for more details. Information about how to use the driver is available in the [Teradata JDBC Driver Reference](https://downloads.teradata.com/doc/connectivity/jdbc/reference/current/frameset.html).
+Information about how to use the driver is available in the [Teradata JDBC Driver Reference](https://downloads.teradata.com/doc/connectivity/jdbc/reference/current/frameset.html).
 
 For community support, please visit [Teradata Community](https://support.teradata.com/community).
-
-The Teradata JDBC Driver is distributed as a platform-independent jar file. For downloading convenience, the platform-independent jar file and readme file are bundled together and provided in both zip format and tar format. The zip and tar files contain exactly the same set of files.
-
-Download either the zip file or the tar file, and unzip (or untar) the downloaded file into a directory of your choice, and then set your classpath to refer to the necessary jar file.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The Teradata JDBC Driver enables Java applications to connect to the Teradata Database. The driver is available in [Maven Central](https://search.maven.org/search?q=a:terajdbc). 
+The Teradata JDBC Driver enables Java applications to connect to the Teradata Database. The driver is available in [Maven Central](https://central.sonatype.com/artifact/com.teradata.jdbc/terajdbc/20.00.00.06/versions). 
 
 Information about how to use the driver is available in the [Teradata JDBC Driver Reference](https://downloads.teradata.com/doc/connectivity/jdbc/reference/current/frameset.html).
 


### PR DESCRIPTION
 instead of linking to the Downloads website.